### PR TITLE
Bugfix 13

### DIFF
--- a/turnstile/checks/pre_commit/codevalidator.py
+++ b/turnstile/checks/pre_commit/codevalidator.py
@@ -37,7 +37,7 @@ def codevalidator(files_to_check, temporary_dir=None, custom_config=None, fix=Fa
 
     logger.debug('Command Arguments: %s', arguments)
 
-    process = subprocess.Popen(arguments, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen(arguments, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
     stdout, stderr = process.communicate()
     logger.debug('Standard Output: %s', stdout)
     logger.debug('Standard Error: %s', stderr)

--- a/turnstile/version.py
+++ b/turnstile/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-version = '1.5.1'
+version = '1.6.2'


### PR DESCRIPTION
Using Universal Newlines will ensure the codevalidator output will be properly decoded.
