### PR TITLE
Check-Names in config only work with underscores

### DIFF
--- a/.turnstile.yml
+++ b/.turnstile.yml
@@ -1,8 +1,8 @@
 checks:
     - specification
-    - branch-release
+    - branch_release
     - codevalidator
-    - protect-master
+    - protect_master
 specification:
     allowed_schemes: ['https']
     allowed_formats: ['uri', 'github']

--- a/turnstile/checks/__init__.py
+++ b/turnstile/checks/__init__.py
@@ -101,7 +101,10 @@ def run_checks(hook_name, user_configuration, repository_configuration, check_ob
     logger = output.get_sub_logger(hook_name.replace('_', '-'), 'run_checks')
     failed_checks = 0
     checklist = repository_configuration.get('checks', [])
-    check_functions = get_checks(hook_name)
+    checklist = [x.replace('-', '_') for x in checklist]
+    logger.debug('Configured Checks: %s', checklist)
+    check_functions = list(get_checks(hook_name))
+    logger.debug('Available Checks: %s', [f[0] for f in check_functions])
     checks_to_run = (check for check_name, check in check_functions if check_name in checklist)
     for check in checks_to_run:
 


### PR DESCRIPTION
Changed '-' to '_' in turnstile.yml, so checks will be discovered.

TODO: Find out if this breaks the config of these checks.
